### PR TITLE
월드컵 실행 화면 개발

### DIFF
--- a/data/src/main/java/com/daejol/catdata/api/CatImagesApi.kt
+++ b/data/src/main/java/com/daejol/catdata/api/CatImagesApi.kt
@@ -3,11 +3,15 @@ package com.daejol.catdata.api
 import com.daejol.catdata.dto.CatImageDto
 import okhttp3.Response
 import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
 
 public interface CatImagesApi {
     // https://api.thecatapi.com/v1/images/search?limit=10
-    @GET("images/search")
-    suspend fun getCatImages(): retrofit2.Response<List<CatImageDto>?>
+    @GET("images/search?format=json&has_breeds=true")
+    suspend fun getCatImages(
+        @Query("limit") limit: Int
+    ): retrofit2.Response<List<CatImageDto>?>
 
 
 }

--- a/data/src/main/java/com/daejol/catdata/repository/CatImagesRepositoryImpl.kt
+++ b/data/src/main/java/com/daejol/catdata/repository/CatImagesRepositoryImpl.kt
@@ -12,16 +12,15 @@ import javax.inject.Inject
 class CatImagesRepositoryImpl @Inject constructor(
     private val catImagesApi: CatImagesApi
 ) : CatImagesRepository {
-    override suspend fun getCatRandomImages(imageCount: Int): Flow<DataState<List<ImageEntity>>> = flow {
-        try {
+    override suspend fun getCatRandomImages(imageCount: Int): Flow<DataState<List<ImageEntity>>> =
+        flow {
+
             val catImages =
                 catImagesApi.getCatImages(imageCount).body()?.map { it.toDomain() }?.toList()
             println(catImages)
             emit(DataState.Success(data = catImages))
-        } catch (e: Exception) {
-            emit(DataState.Fail(data = null, exception = e))
+
         }
-    }
 
 
 }

--- a/data/src/main/java/com/daejol/catdata/repository/CatImagesRepositoryImpl.kt
+++ b/data/src/main/java/com/daejol/catdata/repository/CatImagesRepositoryImpl.kt
@@ -15,7 +15,7 @@ class CatImagesRepositoryImpl @Inject constructor(
     override suspend fun getCatRandomImages(imageCount: Int): Flow<DataState<List<ImageEntity>>> = flow {
         try {
             val catImages =
-                catImagesApi.getCatImages().body()?.map { it.toDomain() }?.toList()
+                catImagesApi.getCatImages(imageCount).body()?.map { it.toDomain() }?.toList()
             println(catImages)
             emit(DataState.Success(data = catImages))
         } catch (e: Exception) {

--- a/data/src/main/java/di/AppModule.kt
+++ b/data/src/main/java/di/AppModule.kt
@@ -101,7 +101,7 @@ object AppModule {
     class CatRetrofitInterceptor : Interceptor {
         override fun intercept(chain: Interceptor.Chain): Response {
             val request = chain.request()
-            val params = mapOf<String, String>("api-key" to ApiConst.CAT_API_KEY)
+            val params = mapOf<String, String>("api_key" to ApiConst.CAT_API_KEY)
 
             val uriBuilder = request.url.newBuilder()
             params.forEach { (key, value) ->
@@ -122,7 +122,7 @@ object AppModule {
     class DogRetrofitInterceptor : Interceptor {
         override fun intercept(chain: Interceptor.Chain): Response {
             val request = chain.request()
-            val params = mapOf<String, String>("api-key" to ApiConst.DOG_API_KEY)
+            val params = mapOf<String, String>("api_key" to ApiConst.DOG_API_KEY)
 
             val uriBuilder = request.url.newBuilder()
             params.forEach { (key, value) ->

--- a/domain/src/main/java/di/UsecaseModule.kt
+++ b/domain/src/main/java/di/UsecaseModule.kt
@@ -1,6 +1,7 @@
 package di
 
 import com.daejol.domain.repository.CatImagesRepository
+import com.daejol.domain.repository.DogImagesRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -16,7 +17,10 @@ object UsecaseModule {
 
     @Singleton
     @Provides
-    fun provideGetImageUsecase(catImagesRepository: CatImagesRepository): GetImageUsecase {
-        return GetImageUsecase(catImagesRepository)
+    fun provideGetImageUsecase(
+        catImagesRepository: CatImagesRepository,
+        dogImagesRepository: DogImagesRepository
+    ): GetImageUsecase {
+        return GetImageUsecase(catImagesRepository, dogImagesRepository)
     }
 }

--- a/domain/src/main/java/usecase/GetImageUsecase.kt
+++ b/domain/src/main/java/usecase/GetImageUsecase.kt
@@ -1,14 +1,56 @@
 package usecase
 
 import com.daejol.domain.repository.CatImagesRepository
+import com.daejol.domain.repository.DogImagesRepository
 import entity.ImageEntity
 import kotlinx.coroutines.flow.*
 import javax.inject.Inject
 
+enum class WorldCupType {
+    CAT, DOG, COMBINED
+}
+
 class GetImageUsecase @Inject constructor(
-    private val catImagesRepository: CatImagesRepository
+    private val catImagesRepository: CatImagesRepository,
+    private val dogImagesRepository: DogImagesRepository
 ) {
-    suspend fun getRandomCatImages(randomImageCount: Int): Flow<List<ImageEntity>?>? {
+    suspend fun getAnimalList(
+        type: WorldCupType,
+        randomImageCount: Int
+    ): Flow<List<ImageEntity>> {
+        return when (type) {
+            WorldCupType.CAT -> getRandomCatImages(randomImageCount)
+                ?: flow { listOf<ImageEntity>() }
+
+            WorldCupType.DOG -> getRandomCatImages(randomImageCount)
+                ?: flow { listOf<ImageEntity>() }
+
+            WorldCupType.COMBINED -> merge(
+                getRandomCatImages(randomImageCount / 2)?.map { it } ?: flow { },
+                getRandomDogImages(randomImageCount / 2)?.map { it } ?: flow { }
+            )
+        }
+    }
+
+    private suspend fun getRandomCatImages(randomImageCount: Int): Flow<List<ImageEntity>>? {
+        try {
+            val flow = catImagesRepository.getCatRandomImages(randomImageCount).map {
+                return@map it.on(
+                    // TODO: Entity 자체를 넘겨주는 것이 좋을까? 아니면 정말 필요한 것만 한 번 더 정제해서
+                    // TODO: 주는 것이 나을까?
+                    onSuccess = { it },
+                    // TODO: onError일 때 어떤 데이터를 던져주는 것이 좋을까?
+                    onError = { throw Exception() }
+                ) ?: listOf<ImageEntity>()
+            }
+
+            return flow
+        } catch (e: Exception) {
+            return null
+        }
+    }
+
+    private suspend fun getRandomDogImages(randomImageCount: Int): Flow<List<ImageEntity>>? {
         try {
             val flow = catImagesRepository.getCatRandomImages(randomImageCount).map {
                 return@map it.on(
@@ -21,7 +63,7 @@ class GetImageUsecase @Inject constructor(
                     onError = {
                         throw Exception()
                     }
-                )
+                ) ?: listOf<ImageEntity>()
             }
 
             return flow

--- a/domain/src/main/java/usecase/GetImageUsecase.kt
+++ b/domain/src/main/java/usecase/GetImageUsecase.kt
@@ -19,6 +19,7 @@ class GetImageUsecase @Inject constructor(
         type: WorldCupType,
         randomImageCount: Int
     ): Flow<List<ImageEntity>> {
+        println("[keykat] randomImageCount:: $randomImageCount")
         return when (type) {
             WorldCupType.CAT -> getRandomCatImages(randomImageCount)
                 ?: flow { listOf<ImageEntity>() }

--- a/domain/src/main/java/usecase/GetImageUsecase.kt
+++ b/domain/src/main/java/usecase/GetImageUsecase.kt
@@ -1,13 +1,14 @@
 package usecase
 
+import androidx.versionedparcelable.ParcelField
 import com.daejol.domain.repository.CatImagesRepository
 import com.daejol.domain.repository.DogImagesRepository
 import entity.ImageEntity
 import kotlinx.coroutines.flow.*
 import javax.inject.Inject
 
-enum class WorldCupType {
-    CAT, DOG, COMBINED
+enum class WorldCupType(value: String) {
+    CAT("CAT"), DOG("DOG"), COMBINED("COMBINED")
 }
 
 class GetImageUsecase @Inject constructor(
@@ -52,7 +53,7 @@ class GetImageUsecase @Inject constructor(
 
     private suspend fun getRandomDogImages(randomImageCount: Int): Flow<List<ImageEntity>>? {
         try {
-            val flow = catImagesRepository.getCatRandomImages(randomImageCount).map {
+            val flow = dogImagesRepository.getDogRandomImages(randomImageCount).map {
                 return@map it.on(
                     // TODO: Entity 자체를 넘겨주는 것이 좋을까? 아니면 정말 필요한 것만 한 번 더 정제해서
                     // TODO: 주는 것이 나을까?

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,7 +90,6 @@ compose-glide = { group = "com.github.skydoves", name = "landscapist-glide", ver
 hilt-viewmodel = { group = "androidx.hilt", name = "hilt-navigation-compose", version = "1.0.0-alpha03" }
 
 
-
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin"}
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin"}

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -88,6 +88,7 @@ dependencies {
     implementation libs.androidx.navigation.ui.ktx
     implementation libs.androidx.navigation.compose
     implementation libs.androidx.material
+    implementation libs.hilt.viewmodel
 
     implementation project(path: ':domain')
 }

--- a/presentation/src/main/java/com/daejol/presentation/MainActivity.kt
+++ b/presentation/src/main/java/com/daejol/presentation/MainActivity.kt
@@ -137,7 +137,7 @@ fun CatDogCupNavHost(
             // TODO: 북마크
         }
         composable(route = Screen.MyPage.route) {
-//             WorldCupScreen(navController = navController, type = "CAT")
+             WorldCupScreen(navController = navController, type = "CAT")
         }
         composable(route = Screen.WorldCupSelection.route) {
             WorldCupScreen(navController = navController, type = "CAT")

--- a/presentation/src/main/java/com/daejol/presentation/MainActivity.kt
+++ b/presentation/src/main/java/com/daejol/presentation/MainActivity.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.content.ContentProviderCompat.requireContext
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.NavDestination.Companion.hierarchy
@@ -33,6 +34,7 @@ import androidx.navigation.navArgument
 import com.daejol.presentation.home.HomeScreen
 import com.daejol.presentation.category.match.PersonalWidget
 import com.daejol.presentation.ui.theme.CatdogcupTheme
+import com.daejol.presentation.worldcup.WorldCupViewModel
 import com.daejol.presentation.worldcup.play.WorldCupPlayScreen
 import com.daejol.presentation.worldcup.selection.WorldCupScreen
 import dagger.hilt.android.AndroidEntryPoint
@@ -122,6 +124,8 @@ fun CatDogCupNavHost(
     navController: NavHostController,
     modifier: Modifier
 ) {
+    val viewModel: WorldCupViewModel = hiltViewModel()
+
     NavHost(
         navController = navController,
         startDestination = Screen.Home.route,
@@ -137,13 +141,13 @@ fun CatDogCupNavHost(
             // TODO: 북마크
         }
         composable(route = Screen.MyPage.route) {
-             WorldCupScreen(navController = navController, type = "CAT")
+            WorldCupScreen(viewModel = viewModel, navController = navController, type = "CAT")
         }
         composable(route = Screen.WorldCupSelection.route) {
-            WorldCupScreen(navController = navController, type = "CAT")
+            WorldCupScreen(viewModel = viewModel, navController = navController, type = "CAT")
         }
         composable(route = Screen.WorldCupPlay.route) { backStackEntry ->
-            WorldCupPlayScreen()
+            WorldCupPlayScreen(viewModel = viewModel)
         }
     }
 }

--- a/presentation/src/main/java/com/daejol/presentation/MainActivity.kt
+++ b/presentation/src/main/java/com/daejol/presentation/MainActivity.kt
@@ -3,42 +3,15 @@ package com.daejol.presentation
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.core.content.ContentProviderCompat.requireContext
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import androidx.navigation.NavDestination.Companion.hierarchy
-import androidx.navigation.NavGraph.Companion.findStartDestination
-import androidx.navigation.NavHostController
-import androidx.navigation.NavType
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.compose.rememberNavController
-import androidx.navigation.navArgument
-import com.daejol.presentation.home.HomeScreen
-import com.daejol.presentation.category.match.PersonalWidget
+import com.daejol.presentation.main.MainScreen
 import com.daejol.presentation.ui.theme.CatdogcupTheme
-import com.daejol.presentation.worldcup.WorldCupViewModel
-import com.daejol.presentation.worldcup.play.WorldCupPlayScreen
-import com.daejol.presentation.worldcup.selection.WorldCupScreen
 import dagger.hilt.android.AndroidEntryPoint
-import usecase.WorldCupType
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -53,11 +26,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    CatDogCupApp()
-//                    WorldCupScreen(
-//                        type = WorldCupType.CAT
-//                    )
-//                    WorldCupPlayScreen()
+                    MainScreen()
                 }
             }
         }
@@ -65,90 +34,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onResume() {
         super.onResume()
-//        CoroutineScope(Dispatchers.IO).launch {
-//            getImageUsecase.getRandomCatImages(10)?.collect {
-//                it?.forEach { list ->
-//                    println("[keykat] list: $list")
-//                }
-//            }
-//        }
-    }
-}
-
-@Composable
-fun CatDogCupApp() {
-    val items = listOf(
-        Screen.Home,
-        Screen.Category,
-        Screen.Bookmark,
-        Screen.MyPage,
-    )
-    val navController = rememberNavController()
-    Scaffold(
-        bottomBar = {
-            NavigationBar {
-                val navBackStackEntry by navController.currentBackStackEntryAsState()
-                val currentDestination = navBackStackEntry?.destination
-                items.forEach { screen ->
-                    NavigationBarItem(
-                        icon = {
-                            screen.icon?.let {
-                                Icon(
-                                    screen.icon,
-                                    contentDescription = null
-                                )
-                            }
-                        },
-                        label = { Text(stringResource(screen.resourceId)) },
-                        selected = currentDestination?.hierarchy?.any { it.route == screen.route } == true,
-                        onClick = {
-                            navController.navigate(screen.route) {
-                                popUpTo(navController.graph.findStartDestination().id) {
-                                    saveState = true
-                                }
-                                launchSingleTop = true
-                                restoreState = true
-                            }
-                        }
-                    )
-                }
-            }
-        }
-    ) { innerPadding ->
-        CatDogCupNavHost(navController, Modifier.padding(innerPadding))
-    }
-}
-
-@Composable
-fun CatDogCupNavHost(
-    navController: NavHostController,
-    modifier: Modifier
-) {
-    val viewModel: WorldCupViewModel = hiltViewModel()
-
-    NavHost(
-        navController = navController,
-        startDestination = Screen.Home.route,
-        modifier = modifier
-    ) {
-        composable(route = Screen.Home.route) {
-            HomeScreen()
-        }
-        composable(route = Screen.Category.route) {
-            PersonalWidget()
-        }
-        composable(route = Screen.Bookmark.route) {
-            // TODO: 북마크
-        }
-        composable(route = Screen.MyPage.route) {
-            WorldCupScreen(viewModel = viewModel, navController = navController, type = "CAT")
-        }
-        composable(route = Screen.WorldCupSelection.route) {
-            WorldCupScreen(viewModel = viewModel, navController = navController, type = "CAT")
-        }
-        composable(route = Screen.WorldCupPlay.route) { backStackEntry ->
-            WorldCupPlayScreen(viewModel = viewModel)
-        }
     }
 }
 

--- a/presentation/src/main/java/com/daejol/presentation/MainActivity.kt
+++ b/presentation/src/main/java/com/daejol/presentation/MainActivity.kt
@@ -3,6 +3,7 @@ package com.daejol.presentation
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
@@ -17,26 +18,28 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.content.ContentProviderCompat.requireContext
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import com.daejol.presentation.home.HomeScreen
 import com.daejol.presentation.category.match.PersonalWidget
 import com.daejol.presentation.ui.theme.CatdogcupTheme
+import com.daejol.presentation.worldcup.play.WorldCupPlayScreen
+import com.daejol.presentation.worldcup.selection.WorldCupScreen
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import usecase.GetImageUsecase
-import javax.inject.Inject
+import usecase.WorldCupType
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
-    @Inject lateinit var getImageUsecase: GetImageUsecase
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -49,6 +52,10 @@ class MainActivity : ComponentActivity() {
                     color = MaterialTheme.colorScheme.background
                 ) {
                     CatDogCupApp()
+//                    WorldCupScreen(
+//                        type = WorldCupType.CAT
+//                    )
+//                    WorldCupPlayScreen()
                 }
             }
         }
@@ -56,13 +63,13 @@ class MainActivity : ComponentActivity() {
 
     override fun onResume() {
         super.onResume()
-        CoroutineScope(Dispatchers.IO).launch {
-            getImageUsecase.getRandomCatImages(10)?.collect {
-                it?.forEach { list ->
-                    println("[keykat] list: $list")
-                }
-            }
-        }
+//        CoroutineScope(Dispatchers.IO).launch {
+//            getImageUsecase.getRandomCatImages(10)?.collect {
+//                it?.forEach { list ->
+//                    println("[keykat] list: $list")
+//                }
+//            }
+//        }
     }
 }
 
@@ -72,7 +79,7 @@ fun CatDogCupApp() {
         Screen.Home,
         Screen.Category,
         Screen.Bookmark,
-        Screen.MyPage
+        Screen.MyPage,
     )
     val navController = rememberNavController()
     Scaffold(
@@ -82,7 +89,14 @@ fun CatDogCupApp() {
                 val currentDestination = navBackStackEntry?.destination
                 items.forEach { screen ->
                     NavigationBarItem(
-                        icon = { Icon(screen.icon, contentDescription = null) },
+                        icon = {
+                            screen.icon?.let {
+                                Icon(
+                                    screen.icon,
+                                    contentDescription = null
+                                )
+                            }
+                        },
                         label = { Text(stringResource(screen.resourceId)) },
                         selected = currentDestination?.hierarchy?.any { it.route == screen.route } == true,
                         onClick = {
@@ -123,7 +137,13 @@ fun CatDogCupNavHost(
             // TODO: 북마크
         }
         composable(route = Screen.MyPage.route) {
-            // TODO: 마이페이지
+//             WorldCupScreen(navController = navController, type = "CAT")
+        }
+        composable(route = Screen.WorldCupSelection.route) {
+            WorldCupScreen(navController = navController, type = "CAT")
+        }
+        composable(route = Screen.WorldCupPlay.route) { backStackEntry ->
+            WorldCupPlayScreen()
         }
     }
 }
@@ -132,6 +152,6 @@ fun CatDogCupNavHost(
 @Composable
 fun DefaultPreview() {
     CatdogcupTheme {
-        CatDogCupApp()
+//        CatDogCupApp()
     }
 }

--- a/presentation/src/main/java/com/daejol/presentation/Screen.kt
+++ b/presentation/src/main/java/com/daejol/presentation/Screen.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 sealed class Screen(
     val route: String,
     @StringRes val resourceId: Int,
-    val icon : ImageVector
+    val icon : ImageVector? = null
 ) {
     // TODO: 아이콘 수정
     data object Home : Screen("home", R.string.home, Icons.Filled.Home)
@@ -21,4 +21,10 @@ sealed class Screen(
     data object Bookmark : Screen("bookmark", R.string.bookmark, Icons.Filled.Star)
 
     data object MyPage : Screen("my_page", R.string.my_page, Icons.Filled.Person)
+
+    data object WorldCupSelection : Screen("worldcup/selection", R.string.worldcup_selection)
+
+    data object WorldCupPlay : Screen("worldcup/play", R.string.worldcup_play)
+
+    data object WorldCupResult : Screen("worldcup/result", R.string.worldcup_result)
 }

--- a/presentation/src/main/java/com/daejol/presentation/common/ui/BottomButton.kt
+++ b/presentation/src/main/java/com/daejol/presentation/common/ui/BottomButton.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.navigation.compose.rememberNavController
 import com.daejol.presentation.ui.theme.CustomTextStyle
 import com.daejol.presentation.ui.theme.Orange100
 import com.daejol.presentation.ui.theme.Pretendard
@@ -27,7 +28,9 @@ fun BottomButton(onClick: () -> Unit) {
             .wrapContentHeight(),
         shape = RectangleShape,
         colors = ButtonColors(Orange100, Orange100, Orange100, Orange100),
-        onClick = { onClick.invoke() },
+        onClick = {
+            onClick.invoke()
+        },
     ) {
         Column {
             Text(

--- a/presentation/src/main/java/com/daejol/presentation/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/daejol/presentation/home/HomeScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavController
 import com.daejol.presentation.R
 import com.daejol.presentation.ui.theme.CatdogcupTheme
 import com.daejol.presentation.ui.theme.Orange80
@@ -35,7 +36,9 @@ import com.daejol.presentation.ui.theme.Typography
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun HomeScreen() {
+fun HomeScreen(
+    navController: NavController? = null
+) {
     Scaffold(
         topBar = {
             TopAppBar(
@@ -75,7 +78,7 @@ fun HomeScreen() {
                 .padding(innerPadding)
                 .verticalScroll(rememberScrollState())
         ) {
-            WorldCupContent()
+            WorldCupContent(navController)
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.space_xs)))
             PopularCatDogContent()
         }

--- a/presentation/src/main/java/com/daejol/presentation/home/WorldCupCard.kt
+++ b/presentation/src/main/java/com/daejol/presentation/home/WorldCupCard.kt
@@ -3,6 +3,7 @@ package com.daejol.presentation.home
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -16,6 +17,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -30,72 +32,78 @@ import com.daejol.presentation.R
 import com.daejol.presentation.ui.theme.CatdogcupTheme
 import com.daejol.presentation.ui.theme.Typography
 import com.daejol.presentation.ui.theme.White100
+import usecase.WorldCupType
 
 @Composable
 fun WorldCupCard(
     @StringRes title: Int = R.string.cat_world_cup_title,
     @StringRes desc: Int = R.string.cat_world_cup_desc,
     @StringRes button: Int = R.string.cat_world_cup_button,
-    @DrawableRes painter: Int = R.drawable.cat
+    @DrawableRes painter: Int = R.drawable.cat,
+    onClick: () -> Unit
 ) {
-    ElevatedCard(
-        elevation = CardDefaults.cardElevation(
-            defaultElevation = dimensionResource(id = R.dimen.elevation_default)
-        ),
-        colors = CardDefaults.cardColors(
-            containerColor = White100
-        ),
-        modifier = Modifier
-            .fillMaxWidth()
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(
-                start = dimensionResource(id = R.dimen.space_m),
-                top = dimensionResource(id = R.dimen.space_m),
-                bottom = dimensionResource(id = R.dimen.space_xxs),
-                end = dimensionResource(id = R.dimen.space_m)
-            )
+    Surface(onClick = {
+        onClick.invoke()
+    }) {
+        ElevatedCard(
+            elevation = CardDefaults.cardElevation(
+                defaultElevation = dimensionResource(id = R.dimen.elevation_default)
+            ),
+            colors = CardDefaults.cardColors(
+                containerColor = White100
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
         ) {
-            Column(
-                Modifier.weight(1f)
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(
+                    start = dimensionResource(id = R.dimen.space_m),
+                    top = dimensionResource(id = R.dimen.space_m),
+                    bottom = dimensionResource(id = R.dimen.space_xxs),
+                    end = dimensionResource(id = R.dimen.space_m)
+                )
             ) {
-                Text(
-                    text = stringResource(id = title),
-                    fontSize = dimensionResource(id = R.dimen.text_m).value.sp,
-                    style = Typography.titleSmall
-                )
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.space_xs)))
-                Text(
-                    text = stringResource(id = desc),
-                    style = Typography.bodySmall
-                )
-                Button(
-                    onClick = { /*TODO*/ },
-                    contentPadding = PaddingValues(dimensionResource(id = R.dimen.space_xxs)),
-                    modifier = Modifier
-                        .defaultMinSize(
-                            minWidth = ButtonDefaults.MinWidth,
-                            minHeight = 1.dp
-                        )
+                Column(
+                    Modifier.weight(1f)
                 ) {
                     Text(
-                        text = stringResource(id = button),
-                        fontSize = dimensionResource(id = R.dimen.text_xxs).value.sp,
-                        style = Typography.titleLarge,
+                        text = stringResource(id = title),
+                        fontSize = dimensionResource(id = R.dimen.text_m).value.sp,
+                        style = Typography.titleSmall
+                    )
+                    Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.space_xs)))
+                    Text(
+                        text = stringResource(id = desc),
+                        style = Typography.bodySmall
+                    )
+                    Button(
+                        onClick = { /*TODO*/ },
+                        contentPadding = PaddingValues(dimensionResource(id = R.dimen.space_xxs)),
+                        modifier = Modifier
+                            .defaultMinSize(
+                                minWidth = ButtonDefaults.MinWidth,
+                                minHeight = 1.dp
+                            )
+                    ) {
+                        Text(
+                            text = stringResource(id = button),
+                            fontSize = dimensionResource(id = R.dimen.text_xxs).value.sp,
+                            style = Typography.titleLarge,
+                        )
+                    }
+                }
+                Column {
+                    Image(
+                        painter = painterResource(id = painter),
+                        contentDescription = null,
+                        modifier = Modifier
+                            .size(dimensionResource(id = R.dimen.world_cup_card_image_size))
+                    )
+                    Spacer(
+                        modifier = Modifier.height(dimensionResource(id = R.dimen.space_s))
                     )
                 }
-            }
-            Column {
-                Image(
-                    painter = painterResource(id = painter),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .size(dimensionResource(id = R.dimen.world_cup_card_image_size))
-                )
-                Spacer(
-                    modifier = Modifier.height(dimensionResource(id = R.dimen.space_s))
-                )
             }
         }
     }
@@ -105,6 +113,6 @@ fun WorldCupCard(
 @Composable
 fun WorldCupCardPreview() {
     CatdogcupTheme {
-        WorldCupCard()
+        WorldCupCard(onClick = {})
     }
 }

--- a/presentation/src/main/java/com/daejol/presentation/home/WorldCupContent.kt
+++ b/presentation/src/main/java/com/daejol/presentation/home/WorldCupContent.kt
@@ -10,11 +10,19 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavController
 import com.daejol.presentation.R
+import com.daejol.presentation.Screen
+import com.daejol.presentation.main.worldCupViewModel
 import com.daejol.presentation.ui.theme.CatdogcupTheme
+import usecase.WorldCupType
 
 @Composable
-fun WorldCupContent() {
+fun WorldCupContent(
+    navController: NavController? = null
+) {
+    val worldCupViewModel = worldCupViewModel()
+
     Column(
         modifier = Modifier.padding(dimensionResource(id = R.dimen.space_m))
     ) {
@@ -24,21 +32,33 @@ fun WorldCupContent() {
             R.string.cat_world_cup_title,
             R.string.cat_world_cup_desc,
             R.string.cat_world_cup_button,
-            R.drawable.cat
+            R.drawable.cat,
+            onClick = {
+                worldCupViewModel.setType(WorldCupType.CAT)
+                navController?.navigate(Screen.WorldCupSelection.route)
+            }
         )
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.space_m)))
         WorldCupCard(
             R.string.dog_world_cup_title,
             R.string.dog_world_cup_desc,
             R.string.dog_world_cup_button,
-            R.drawable.dog
+            R.drawable.dog,
+            onClick = {
+                worldCupViewModel.setType(WorldCupType.DOG)
+                navController?.navigate(Screen.WorldCupSelection.route)
+            }
         )
         Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.space_m)))
         WorldCupCard(
             R.string.mixed_world_cup_title,
             R.string.mixed_world_cup_desc,
             R.string.mixed_world_cup_button,
-            R.drawable.catdog
+            R.drawable.catdog,
+            onClick = {
+                worldCupViewModel.setType(WorldCupType.COMBINED)
+                navController?.navigate(Screen.WorldCupSelection.route)
+            }
         )
     }
 }

--- a/presentation/src/main/java/com/daejol/presentation/main/AppState.kt
+++ b/presentation/src/main/java/com/daejol/presentation/main/AppState.kt
@@ -1,0 +1,55 @@
+package com.daejol.presentation.main
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.lifecycle.Lifecycle
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavDestination
+import androidx.navigation.NavGraph
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import com.daejol.presentation.Screen
+
+@Stable
+class AppState(
+    val navController: NavHostController
+) {
+    val disableBottomBarScreenList = listOf(
+        Screen.WorldCupSelection.route,
+        Screen.WorldCupPlay.route,
+        Screen.WorldCupResult.route
+    )
+
+    val shouldShowBottomBar: Boolean
+        @Composable get() = navController
+            .currentBackStackEntryAsState().value?.destination?.route !in disableBottomBarScreenList
+
+    val currentRoute: String?
+        get() = navController.currentDestination?.route
+
+    fun upPress() {
+        navController.navigateUp()
+    }
+
+    fun navigateToBottomBarRoute(route: String) {
+        if (route != currentRoute) {
+            navController.navigate(route) {
+                launchSingleTop = true
+                restoreState = true
+                popUpTo(findStartDestination(navController.graph).id) {
+                    saveState = true
+                }
+            }
+        }
+    }
+}
+
+private fun NavBackStackEntry.lifecycleIsResumed() =
+    this.lifecycle.currentState == Lifecycle.State.RESUMED
+
+private val NavGraph.startDestination: NavDestination?
+    get() = findNode(startDestinationId)
+
+private tailrec fun findStartDestination(graph: NavDestination): NavDestination {
+    return if (graph is NavGraph) findStartDestination(graph.startDestination!!) else graph
+}

--- a/presentation/src/main/java/com/daejol/presentation/main/MainNavHost.kt
+++ b/presentation/src/main/java/com/daejol/presentation/main/MainNavHost.kt
@@ -1,0 +1,59 @@
+package com.daejol.presentation.main
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import com.daejol.presentation.Screen
+import com.daejol.presentation.category.match.PersonalWidget
+import com.daejol.presentation.home.HomeScreen
+import com.daejol.presentation.worldcup.play.WorldCupPlayScreen
+import com.daejol.presentation.worldcup.result.WorldCupResultScreen
+import com.daejol.presentation.worldcup.selection.WorldCupScreen
+
+@Composable
+fun MainNavHost(
+    navController: NavHostController,
+    modifier: Modifier
+) {
+    val worldCupViewModel = worldCupViewModel()
+
+    NavHost(
+        navController = navController,
+        startDestination = Screen.Home.route,
+        modifier = modifier
+    ) {
+        composable(route = Screen.Home.route) {
+            HomeScreen(navController)
+        }
+        composable(route = Screen.Category.route) {
+            PersonalWidget()
+        }
+        composable(route = Screen.Bookmark.route) {
+            // TODO: 북마크
+        }
+        composable(route = Screen.MyPage.route) {
+            // TODO: 마이페이지
+        }
+        composable(route = Screen.WorldCupSelection.route) {
+            WorldCupScreen(
+                viewModel = worldCupViewModel,
+                type = "CAT",
+                navController = navController
+            )
+        }
+        composable(route = Screen.WorldCupPlay.route) {
+            WorldCupPlayScreen(
+                viewModel = worldCupViewModel,
+                navController = navController
+            )
+        }
+        composable(route = Screen.WorldCupResult.route) {
+            WorldCupResultScreen(
+                viewModel = worldCupViewModel,
+                navController = navController
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/daejol/presentation/main/MainRemember.kt
+++ b/presentation/src/main/java/com/daejol/presentation/main/MainRemember.kt
@@ -1,0 +1,16 @@
+package com.daejol.presentation.main
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import com.daejol.presentation.worldcup.WorldCupViewModel
+
+@Composable
+fun worldCupViewModel(): WorldCupViewModel = hiltViewModel()
+
+@Composable
+fun rememberAppState(
+    navController: NavHostController = rememberNavController()
+) = remember(navController) { AppState(navController) }

--- a/presentation/src/main/java/com/daejol/presentation/main/MainScreen.kt
+++ b/presentation/src/main/java/com/daejol/presentation/main/MainScreen.kt
@@ -1,0 +1,68 @@
+package com.daejol.presentation.main
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavDestination.Companion.hierarchy
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import com.daejol.presentation.Screen
+
+@Composable
+fun MainScreen() {
+    val items = listOf(
+        Screen.Home,
+        Screen.Category,
+        Screen.Bookmark,
+        Screen.MyPage,
+    )
+    val appState = rememberAppState()
+    val navController = appState.navController
+
+    Scaffold(
+        bottomBar = {
+            if (appState.shouldShowBottomBar) {
+                NavigationBar {
+                    val navBackStackEntry by navController.currentBackStackEntryAsState()
+                    val currentDestination = navBackStackEntry?.destination
+                    items.forEach { screen ->
+                        NavigationBarItem(
+                            icon = {
+                                screen.icon?.let {
+                                    Icon(
+                                        screen.icon,
+                                        contentDescription = null
+                                    )
+                                }
+                            },
+                            label = { Text(stringResource(screen.resourceId)) },
+                            selected = currentDestination?.hierarchy?.any { it.route == screen.route } == true,
+                            onClick = {
+                                navController.navigate(screen.route) {
+                                    popUpTo(navController.graph.findStartDestination().id) {
+                                        saveState = true
+                                    }
+                                    launchSingleTop = true
+                                    restoreState = true
+                                }
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    ) { innerPadding ->
+        MainNavHost(navController, Modifier.padding(innerPadding))
+    }
+}
+

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/WorldCupViewModel.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/WorldCupViewModel.kt
@@ -1,13 +1,16 @@
 package com.daejol.presentation.worldcup
 
 import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
-class WorldCupViewModel @Inject constructor(): ViewModel() {
+class WorldCupViewModel @Inject constructor(
+
+): ViewModel() {
     private val _worldCupLevel = mutableStateOf("16강")
     val worldCupLevel: State<String> = _worldCupLevel
 
@@ -19,6 +22,12 @@ class WorldCupViewModel @Inject constructor(): ViewModel() {
 
     private val _share = mutableStateOf(true)
     val share: State<Boolean> = _share
+
+    private val _currentGameLevel = mutableStateOf(0)
+    val currentGameLevel: State<Int> = _currentGameLevel
+
+    private val _worldCupAnimalList = mutableStateListOf()
+     al worldCupAnimalList: State
 
     fun setLevel(level: String) {
         _worldCupLevel.value = level
@@ -34,5 +43,9 @@ class WorldCupViewModel @Inject constructor(): ViewModel() {
 
     fun allowShare(share: Boolean) {
         _share.value = share
+    }
+
+    fun updateGameLevel(level: Int) {
+        _currentGameLevel.value = level
     }
 }

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/WorldCupViewModel.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/WorldCupViewModel.kt
@@ -1,16 +1,27 @@
 package com.daejol.presentation.worldcup
 
 import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import entity.ImageEntity
+import kotlinx.coroutines.launch
+import okhttp3.internal.toImmutableList
+import usecase.GetImageUsecase
+import usecase.WorldCupType
 import javax.inject.Inject
 
 @HiltViewModel
 class WorldCupViewModel @Inject constructor(
+    val imageUsecase: GetImageUsecase
+) : ViewModel() {
+    private val _worldCupType = mutableStateOf(WorldCupType.CAT)
+    val worldCupType: State<WorldCupType> = _worldCupType
 
-): ViewModel() {
     private val _worldCupLevel = mutableStateOf("16강")
     val worldCupLevel: State<String> = _worldCupLevel
 
@@ -23,11 +34,15 @@ class WorldCupViewModel @Inject constructor(
     private val _share = mutableStateOf(true)
     val share: State<Boolean> = _share
 
-    private val _currentGameLevel = mutableStateOf(0)
+    private val _currentGameLevel = mutableIntStateOf(0)
     val currentGameLevel: State<Int> = _currentGameLevel
 
-    private val _worldCupAnimalList = mutableStateListOf()
-     al worldCupAnimalList: State
+    private val _worldCupAnimalList = mutableStateOf(listOf<ImageEntity>())
+    val worldCupAnimalList: State<List<ImageEntity>> = _worldCupAnimalList
+
+    fun setType(type: WorldCupType) {
+        _worldCupType.value = type
+    }
 
     fun setLevel(level: String) {
         _worldCupLevel.value = level
@@ -46,6 +61,19 @@ class WorldCupViewModel @Inject constructor(
     }
 
     fun updateGameLevel(level: Int) {
-        _currentGameLevel.value = level
+        _currentGameLevel.intValue = level
+    }
+
+    fun getAnimalList() {
+        viewModelScope.launch {
+            imageUsecase.getAnimalList(
+                type = _worldCupType.value,
+                randomImageCount = currentGameLevel.value / 2
+            )
+                .collect {
+                    val list = it.toImmutableList()
+                    _worldCupAnimalList.value = list
+                }
+        }
     }
 }

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/WorldCupViewModel.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/WorldCupViewModel.kt
@@ -90,7 +90,7 @@ class WorldCupViewModel @Inject constructor(
 
     fun initializeGame() {
         if (_gameProgressImageList.value.isEmpty() || _gameProgressImageList.value.last().size != 0) {
-            var gameLevel = _currentGameLevel.value * 2
+            var gameLevel = _currentGameLevel.intValue * 2
             _gameProgressImageList.value.removeAll { true }
 
             while (gameLevel % 2 == 0) {
@@ -108,10 +108,7 @@ class WorldCupViewModel @Inject constructor(
 
             // 다음 대결 상대 정하기
             var element = _gameProgressImageList.value.first()
-            var first = element[0]
-            var second = element[1]
-            _currentMatchImages.value = listOf(first.copy(), second.copy())
-
+            _currentMatchImages.value = element.toList()
         }
     }
 
@@ -120,22 +117,30 @@ class WorldCupViewModel @Inject constructor(
         winner: Int,
         onMatchEnd: () -> Unit
     ) {
-        if (checkEndGame(onMatchEnd)) {
-            return
+        println("[keykat] -------------------------------------------------")
+        _gameProgressImageList.value.forEach { it ->
+            println("[keykat] 현재 게임 상황: _gameProgressImageList: ${it.size}")
         }
+
         removeSelectedMatch(winner)
+        setNextMatchedImages()
 
         if (checkEndGame(onMatchEnd)) {
             return
         }
-        setNextMatchedImages()
+
+        println("[keykat] -------------------------------------------------")
         _gameProgressImageList.value.forEach { it ->
-            println("[keykat] _gameProgressImageList: ${it.size}")
+            println("[keykat] 이후 게임 상황: _gameProgressImageList: ${it.size}")
         }
     }
 
     private fun checkEndGame(onMatchEnd: () -> Unit): Boolean {
         if (_gameProgressImageList.value.last().size != 0) {
+            _gameProgressImageList.value.forEach { it ->
+                println("[keykat] checlEndGame: _gameProgressImageList: ${it}")
+            }
+
             _currentMatchImages.value = listOf(_gameProgressImageList.value.last().last())
             onMatchEnd.invoke()
             return true
@@ -147,7 +152,7 @@ class WorldCupViewModel @Inject constructor(
     private fun removeSelectedMatch(winner: Int) {
         for (i in 0..<_gameProgressImageList.value.size) {
             val element = _gameProgressImageList.value[i]
-            if (element.size > 0) {
+            if (element.size >= 2) {
                 // 일단 현재 이미지가 리스트 내 어떤 이미지인지 판단하고
                 val first = element.removeFirst()
                 val second = element.removeFirst()
@@ -167,16 +172,19 @@ class WorldCupViewModel @Inject constructor(
     private fun setNextMatchedImages() {
         for (i in 0..<_gameProgressImageList.value.size) {
             val element = _gameProgressImageList.value[i]
-            if (element.size > 0) {
+            // 결과가 나왔을 땐 다음 게임 정보로 업데이트할 필요 없음
+            if (element.size >= 2) {
                 // 128 -> 64 -> 32 -> 16 -> 8 -> 4 -> final
                 println("[keykat] ${(i)}강")
-                _currentGameLevel.value =
+                _currentGameLevel.intValue =
                     (2.0).pow((_gameProgressImageList.value.size - i - 1).toDouble()).toInt()
-                _worldCupLevel.value = "${_currentGameLevel.value}강"
-                // 다음 대결 상대 정하기
-                val first = element[0]
-                val second = element[1]
-                _currentMatchImages.value = listOf(first.copy(), second.copy())
+                if (_currentGameLevel.value == 2) {
+                    _worldCupLevel.value = "결승"
+                } else {
+                    _worldCupLevel.value = "${_currentGameLevel.intValue}강"
+                }
+
+                _currentMatchImages.value = element.toList()
 
                 return
             }

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/play/WorldCupPlayScreen.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/play/WorldCupPlayScreen.kt
@@ -1,80 +1,189 @@
 package com.daejol.presentation.worldcup.play
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.Text
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
 import coil.compose.AsyncImage
+import com.daejol.presentation.Screen
+import com.daejol.presentation.ui.theme.BorderRadius
+import com.daejol.presentation.ui.theme.CustomRichText
+import com.daejol.presentation.ui.theme.CustomTextStyle
+import com.daejol.presentation.ui.theme.MoveSans
+import com.daejol.presentation.ui.theme.Orange100
+import com.daejol.presentation.ui.theme.Padding
+import com.daejol.presentation.ui.theme.Pretendard
+import com.daejol.presentation.ui.theme.RichTextAlign
+import com.daejol.presentation.ui.theme.RichTextDecoration
+import com.daejol.presentation.ui.theme.White100
 import com.daejol.presentation.worldcup.WorldCupViewModel
 
 @Composable
 fun WorldCupPlayScreen(
     viewModel: WorldCupViewModel,
+    navController: NavController? = null
 ) {
+    val imageWidth = LocalConfiguration.current.screenWidthDp.dp / 5 * 4 - 10.dp
+    val imageHeight = LocalConfiguration.current.screenWidthDp.dp / 5 * 4 - 20.dp
+
+    val descTextStyle1 = CustomTextStyle(
+        fontSize = 24f,
+        fontWeight = FontWeight.Bold,
+        fontColor = White100,
+        fontFamily = MoveSans
+    )
+
+
     Column(
         modifier = Modifier
-            .fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally
+            .fillMaxWidth()
+            .fillMaxHeight(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Top
     ) {
-        Text(text = viewModel.worldCupLevel.value)
-
-        val first = if (viewModel.currentMatchImages.value.size > 1) {
-            viewModel.currentMatchImages.value.first()
-        } else {
-            null
+        Spacer(modifier = Modifier.height(20.dp))
+        CustomRichText(
+            defaultFontFamily = Pretendard,
+            defaultTextSize = 24f,
+            textAlign = RichTextAlign.Center
+        ) {
+            RichText(text = viewModel.worldCupLevel.value)
         }
+        Spacer(modifier = Modifier.height(20.dp))
 
-        Text(text = first?.id.toString())
-        Surface(
-            onClick = {
-                viewModel.updateMatch(
-                    winner = 0,
-                    onMatchEnd = {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(),
+            contentAlignment = Alignment.Center
+        ) {
+            val firstUrl = if (viewModel.currentMatchImages.value.size > 1) {
+                println("[keykat] viewModel.currentMatchImages: ${viewModel.currentMatchImages}")
+                viewModel.currentMatchImages.value[0]
+            } else {
+                null
+            }
 
+            val secondUrl = if (viewModel.currentMatchImages.value.size > 1) {
+                viewModel.currentMatchImages.value[1]
+            } else {
+                null
+            }
+
+            Column(
+                modifier = Modifier,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                CustomRichText(
+                    defaultFontFamily = MoveSans,
+                    textAlign = RichTextAlign.Center
+                ) {
+                    RichText(text = firstUrl?.breeds?.first()?.name ?: "")
+                }
+                Spacer(modifier = Modifier.height(10.dp))
+
+                Surface(
+                    onClick = {
+                        viewModel.updateMatch(
+                            winner = 0,
+                            onMatchEnd = {
+                                onMatchEnd(navController)
+                            }
+                        )
+                    },
+                ) {
+                    AsyncImage(
+                        model = firstUrl?.url,
+                        contentDescription = "",
+                        modifier = Modifier
+                            .width(imageWidth)
+                            .height(imageHeight)
+                            .padding(5.dp)
+                            .shadow(
+                                elevation = 1.5.dp,
+                                shape = RoundedCornerShape(
+                                    topStart = 20.dp,
+                                    topEnd = 20.dp
+                                )
+                            ),
+                        contentScale = ContentScale.Crop
+                    )
+                }
+                Surface(
+                    onClick = {
+                        viewModel.updateMatch(
+                            winner = 1,
+                            onMatchEnd = {
+                                onMatchEnd(navController)
+                            }
+                        )
                     }
+                ) {
+                    AsyncImage(
+                        model = secondUrl?.url,
+                        contentDescription = "",
+                        modifier = Modifier
+                            .width(imageWidth)
+                            .height(imageHeight)
+                            .padding(5.dp)
+                            .shadow(
+                                elevation = 1.5.dp,
+                                shape = RoundedCornerShape(
+                                    bottomStart = 20.dp,
+                                    bottomEnd = 20.dp
+                                )
+                            ),
+                        contentScale = ContentScale.Crop
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(10.dp))
+                CustomRichText(
+                    defaultFontFamily = MoveSans,
+                    textAlign = RichTextAlign.Center
+                ) {
+                    RichText(text = secondUrl?.breeds?.first()?.name ?: "")
+                }
+            }
+            CustomRichText(
+                defaultFontFamily = MoveSans,
+                textAlign = RichTextAlign.Center
+            ) {
+                RichText(
+                    "VS",
+                    textStyle = descTextStyle1,
+                    decoration = RichTextDecoration(
+                        background = Orange100,
+                        borderRadius = BorderRadius(100f, 100f, 100f, 100f),
+                        padding = Padding(6f, 2f, 6f, 2f)
+                    ),
                 )
             }
-        ) {
-            AsyncImage(
-                model = first?.url,
-                contentDescription = "",
-                modifier = Modifier
-                    .width(100.dp)
-                    .height(100.dp)
-            )
         }
+    }
+}
 
-        val secondUrl = if (viewModel.currentMatchImages.value.size > 1) {
-            viewModel.currentMatchImages.value[1]
-        } else {
-            null
-        }
-
-        Surface(
-            onClick = {
-                viewModel.updateMatch(
-                    winner = 0,
-                    onMatchEnd = {
-
-                    }
-                )
-            }
-        ) {
-            AsyncImage(
-                model = secondUrl?.url,
-                contentDescription = "",
-            )
-        }
-        Text(text = secondUrl?.id.toString())
-
-//        Text(text = )
+private fun onMatchEnd(navController: NavController?) {
+    navController?.navigate(route = Screen.WorldCupResult.route) {
+        popUpTo(0)
     }
 }

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/play/WorldCupPlayScreen.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/play/WorldCupPlayScreen.kt
@@ -1,0 +1,22 @@
+package com.daejol.presentation.worldcup.play
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.daejol.presentation.worldcup.WorldCupViewModel
+import com.daejol.presentation.worldcup.selection.WorldCupPreviewParameterProvider
+import com.daejol.presentation.worldcup.selection.WorldCupType
+
+@Preview
+@Composable
+fun WorldCupPlayScreen(
+    viewModel: WorldCupViewModel = viewModel(),
+) {
+    Column {
+        Text(text = viewModel.worldCupLevel.value)
+        Text(text = viewModel.worldCupLevel.value)
+    }
+}

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/play/WorldCupPlayScreen.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/play/WorldCupPlayScreen.kt
@@ -4,16 +4,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.tooling.preview.PreviewParameter
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.daejol.presentation.worldcup.WorldCupViewModel
-import com.daejol.presentation.worldcup.selection.WorldCupPreviewParameterProvider
-import com.daejol.presentation.worldcup.selection.WorldCupType
 
 @Preview
 @Composable
 fun WorldCupPlayScreen(
-    viewModel: WorldCupViewModel = viewModel(),
+    viewModel: WorldCupViewModel = hiltViewModel(),
 ) {
     Column {
         Text(text = viewModel.worldCupLevel.value)

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/play/WorldCupPlayScreen.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/play/WorldCupPlayScreen.kt
@@ -53,7 +53,6 @@ fun WorldCupPlayScreen(
         fontFamily = MoveSans
     )
 
-
     Column(
         modifier = Modifier
             .fillMaxWidth()

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/play/WorldCupPlayScreen.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/play/WorldCupPlayScreen.kt
@@ -1,19 +1,80 @@
 package com.daejol.presentation.worldcup.play
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.Text
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
 import com.daejol.presentation.worldcup.WorldCupViewModel
 
-@Preview
 @Composable
 fun WorldCupPlayScreen(
-    viewModel: WorldCupViewModel = hiltViewModel(),
+    viewModel: WorldCupViewModel,
 ) {
-    Column {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
         Text(text = viewModel.worldCupLevel.value)
-        Text(text = viewModel.worldCupLevel.value)
+
+        val first = if (viewModel.currentMatchImages.value.size > 1) {
+            viewModel.currentMatchImages.value.first()
+        } else {
+            null
+        }
+
+        Text(text = first?.id.toString())
+        Surface(
+            onClick = {
+                viewModel.updateMatch(
+                    winner = 0,
+                    onMatchEnd = {
+
+                    }
+                )
+            }
+        ) {
+            AsyncImage(
+                model = first?.url,
+                contentDescription = "",
+                modifier = Modifier
+                    .width(100.dp)
+                    .height(100.dp)
+            )
+        }
+
+        val secondUrl = if (viewModel.currentMatchImages.value.size > 1) {
+            viewModel.currentMatchImages.value[1]
+        } else {
+            null
+        }
+
+        Surface(
+            onClick = {
+                viewModel.updateMatch(
+                    winner = 0,
+                    onMatchEnd = {
+
+                    }
+                )
+            }
+        ) {
+            AsyncImage(
+                model = secondUrl?.url,
+                contentDescription = "",
+            )
+        }
+        Text(text = secondUrl?.id.toString())
+
+//        Text(text = )
     }
 }

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/result/WorldCupResultScreen.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/result/WorldCupResultScreen.kt
@@ -1,0 +1,13 @@
+package com.daejol.presentation.worldcup.result
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavController
+import com.daejol.presentation.worldcup.WorldCupViewModel
+
+@Composable
+fun WorldCupResultScreen(
+    viewModel: WorldCupViewModel,
+    navController: NavController? = null
+) {
+
+}

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/selection/WorldCupScreen.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/selection/WorldCupScreen.kt
@@ -38,7 +38,7 @@ class WorldCupPreviewParameterProvider : PreviewParameterProvider<WorldCupType> 
 
 @Composable
 fun WorldCupScreen(
-    viewModel: WorldCupViewModel = hiltViewModel(),
+    viewModel: WorldCupViewModel,
     @PreviewParameter(WorldCupPreviewParameterProvider::class) type: String,
     navController: NavController? = null
 ) {
@@ -72,9 +72,13 @@ fun WorldCupScreen(
         ) {
             BottomButton(
                 onClick = {
-                    viewModel.getAnimalList()
-                    navController?.navigate(
-                        route = Screen.WorldCupPlay.route
+                    viewModel.getAnimalList(
+                        onFinish = {
+                            viewModel.initializeGame()
+                            navController?.navigate(
+                                route = Screen.WorldCupPlay.route
+                            )
+                        }
                     )
                 }
             )

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/selection/WorldCupScreen.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/selection/WorldCupScreen.kt
@@ -15,14 +15,18 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.Navigator
+import androidx.navigation.compose.rememberNavController
+import com.daejol.presentation.Screen
 import com.daejol.presentation.common.ui.BottomButton
 import com.daejol.presentation.worldcup.WorldCupViewModel
 import com.daejol.presentation.worldcup.selection.middle.MiddleSectionWidget
+import usecase.WorldCupType
 
-enum class WorldCupType {
-    CAT, DOG, COMBINED
-}
 
 class WorldCupPreviewParameterProvider : PreviewParameterProvider<WorldCupType> {
     override val values = sequenceOf(
@@ -32,13 +36,14 @@ class WorldCupPreviewParameterProvider : PreviewParameterProvider<WorldCupType> 
     )
 }
 
-@Preview
 @Composable
 fun WorldCupScreen(
-    viewModel: WorldCupViewModel = viewModel(),
-    @PreviewParameter(WorldCupPreviewParameterProvider::class) type: WorldCupType
+    viewModel: WorldCupViewModel = hiltViewModel(),
+    @PreviewParameter(WorldCupPreviewParameterProvider::class) type: String,
+    navController: NavController? = null
 ) {
-    val t = WorldCupType.DOG
+    val t = enumValueOf<WorldCupType>(type)
+    viewModel.setType(t)
 
     return Column(
         verticalArrangement = Arrangement.Bottom,
@@ -65,7 +70,24 @@ fun WorldCupScreen(
         Box(
             contentAlignment = Alignment.BottomCenter,
         ) {
-            BottomButton({})
+            BottomButton(
+                onClick = {
+                    viewModel.getAnimalList()
+                    navController?.navigate(
+                        route = Screen.WorldCupPlay.route
+                    )
+                }
+            )
         }
     }
+}
+
+@Preview
+@Composable
+fun Preview() {
+    WorldCupScreen(
+        viewModel = viewModel(),
+        WorldCupType.CAT.name,
+        null
+    )
 }

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/selection/WorldCupScreen.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/selection/WorldCupScreen.kt
@@ -15,12 +15,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
-import androidx.navigation.NavGraph.Companion.findStartDestination
-import androidx.navigation.Navigator
-import androidx.navigation.compose.rememberNavController
 import com.daejol.presentation.Screen
 import com.daejol.presentation.common.ui.BottomButton
 import com.daejol.presentation.worldcup.WorldCupViewModel
@@ -92,9 +88,5 @@ fun WorldCupScreen(
 @Preview
 @Composable
 fun Preview() {
-    WorldCupScreen(
-        viewModel = viewModel(),
-        WorldCupType.CAT.name,
-        null
-    )
+    WorldCupScreen(viewModel = viewModel(), WorldCupType.CAT.name)
 }

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/selection/WorldCupScreen.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/selection/WorldCupScreen.kt
@@ -83,6 +83,9 @@ fun WorldCupScreen(
                 }
             )
         }
+        Box {
+
+        }
     }
 }
 

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/selection/WorldCupScreen.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/selection/WorldCupScreen.kt
@@ -1,6 +1,6 @@
-package com.daejol.presentation.worldcup
+package com.daejol.presentation.worldcup.selection
 
-import com.daejol.presentation.worldcup.top.TopSectionWidget
+import com.daejol.presentation.worldcup.selection.top.TopSectionWidget
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,7 +17,8 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.daejol.presentation.common.ui.BottomButton
-import com.daejol.presentation.worldcup.middle.MiddleSectionWidget
+import com.daejol.presentation.worldcup.WorldCupViewModel
+import com.daejol.presentation.worldcup.selection.middle.MiddleSectionWidget
 
 enum class WorldCupType {
     CAT, DOG, COMBINED

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/selection/middle/MiddleDropDownSelectionWidget.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/selection/middle/MiddleDropDownSelectionWidget.kt
@@ -29,7 +29,6 @@ import com.daejol.presentation.worldcup.WorldCupViewModel
 fun MiddleDropDownSelectionWidget(
     content: String,
     state: State<String>,
-    viewModel: WorldCupViewModel = viewModel(),
     menus: List<DropdownItems>
 ) {
     var expanded by remember { mutableStateOf(false) }

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/selection/middle/MiddleDropDownSelectionWidget.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/selection/middle/MiddleDropDownSelectionWidget.kt
@@ -1,15 +1,10 @@
-package com.daejol.presentation.worldcup.middle
+package com.daejol.presentation.worldcup.selection.middle
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.ArrowDropDown
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -23,9 +18,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.focusModifier
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/selection/middle/MiddleSectionWidget.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/selection/middle/MiddleSectionWidget.kt
@@ -12,8 +12,8 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.daejol.presentation.worldcup.selection.WorldCupPreviewParameterProvider
-import com.daejol.presentation.worldcup.selection.WorldCupType
 import com.daejol.presentation.worldcup.WorldCupViewModel
+import usecase.WorldCupType
 
 @Preview
 @Composable
@@ -32,11 +32,22 @@ fun MiddleSectionWidget(
             content = "몇 강까지 진행할까요?",
             state = viewModel.worldCupLevel,
             menus = listOf(
-                DropdownItems(text = "16강", onClick = { viewModel.setLevel("16강") }),
-                DropdownItems(text = "32강", onClick = { viewModel.setLevel("32강") }),
-                DropdownItems(text = "64강", onClick = { viewModel.setLevel("64강") }),
-                DropdownItems(text = "128강", onClick = { viewModel.setLevel("128강") }),
-                DropdownItems(text = "256강", onClick = { viewModel.setLevel("256강") }),
+                DropdownItems(text = "16강", onClick = {
+                    viewModel.setLevel("16강")
+                    viewModel.updateGameLevel(16)
+                }),
+                DropdownItems(text = "32강", onClick = {
+                    viewModel.setLevel("32강")
+                    viewModel.updateGameLevel(32)
+                }),
+                DropdownItems(text = "64강", onClick = {
+                    viewModel.setLevel("64강")
+                    viewModel.updateGameLevel(64)
+                }),
+                DropdownItems(text = "128강", onClick = {
+                    viewModel.setLevel("128강")
+                    viewModel.updateGameLevel(128)
+                }),
             ),
         )
 

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/selection/middle/MiddleSectionWidget.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/selection/middle/MiddleSectionWidget.kt
@@ -1,21 +1,18 @@
-package com.daejol.presentation.worldcup.middle
+package com.daejol.presentation.worldcup.selection.middle
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.daejol.presentation.worldcup.WorldCupPreviewParameterProvider
-import com.daejol.presentation.worldcup.WorldCupType
+import com.daejol.presentation.worldcup.selection.WorldCupPreviewParameterProvider
+import com.daejol.presentation.worldcup.selection.WorldCupType
 import com.daejol.presentation.worldcup.WorldCupViewModel
 
 @Preview

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/selection/middle/MiddleSectionWidget.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/selection/middle/MiddleSectionWidget.kt
@@ -15,10 +15,9 @@ import com.daejol.presentation.worldcup.selection.WorldCupPreviewParameterProvid
 import com.daejol.presentation.worldcup.WorldCupViewModel
 import usecase.WorldCupType
 
-@Preview
 @Composable
 fun MiddleSectionWidget(
-    viewModel: WorldCupViewModel = viewModel(),
+    viewModel: WorldCupViewModel,
     @PreviewParameter(WorldCupPreviewParameterProvider::class) type: WorldCupType
 ) {
     Column(

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/selection/middle/MiddleToggleSelectionWidget.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/selection/middle/MiddleToggleSelectionWidget.kt
@@ -1,4 +1,4 @@
-package com.daejol.presentation.worldcup.middle
+package com.daejol.presentation.worldcup.selection.middle
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/selection/top/TopSectionCatImageWidget.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/selection/top/TopSectionCatImageWidget.kt
@@ -1,4 +1,4 @@
-package com.daejol.presentation.worldcup.top
+package com.daejol.presentation.worldcup.selection.top
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
@@ -23,8 +23,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.daejol.presentation.R
 import com.daejol.presentation.ui.theme.Orange80
-import com.daejol.presentation.worldcup.WorldCupPreviewParameterProvider
-import com.daejol.presentation.worldcup.WorldCupType
+import com.daejol.presentation.worldcup.selection.WorldCupPreviewParameterProvider
+import com.daejol.presentation.worldcup.selection.WorldCupType
 
 @Preview
 @Composable

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/selection/top/TopSectionCatImageWidget.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/selection/top/TopSectionCatImageWidget.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.unit.dp
 import com.daejol.presentation.R
 import com.daejol.presentation.ui.theme.Orange80
 import com.daejol.presentation.worldcup.selection.WorldCupPreviewParameterProvider
-import com.daejol.presentation.worldcup.selection.WorldCupType
+import usecase.WorldCupType
 
 @Preview
 @Composable

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/selection/top/TopSectionTitleWidget.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/selection/top/TopSectionTitleWidget.kt
@@ -1,4 +1,4 @@
-package com.daejol.presentation.worldcup.top
+package com.daejol.presentation.worldcup.selection.top
 
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/selection/top/TopSectionWidget.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/selection/top/TopSectionWidget.kt
@@ -1,4 +1,4 @@
-package com.daejol.presentation.worldcup.top
+package com.daejol.presentation.worldcup.selection.top
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -10,8 +10,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
-import com.daejol.presentation.worldcup.WorldCupPreviewParameterProvider
-import com.daejol.presentation.worldcup.WorldCupType
+import com.daejol.presentation.worldcup.selection.WorldCupPreviewParameterProvider
+import com.daejol.presentation.worldcup.selection.WorldCupType
 
 @Preview
 @Composable

--- a/presentation/src/main/java/com/daejol/presentation/worldcup/selection/top/TopSectionWidget.kt
+++ b/presentation/src/main/java/com/daejol/presentation/worldcup/selection/top/TopSectionWidget.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import com.daejol.presentation.worldcup.selection.WorldCupPreviewParameterProvider
-import com.daejol.presentation.worldcup.selection.WorldCupType
+import usecase.WorldCupType
 
 @Preview
 @Composable

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -6,6 +6,9 @@
     <string name="category">카테고리</string>
     <string name="bookmark">북마크</string>
     <string name="my_page">마이페이지</string>
+    <string name="worldcup_selection">월드컵선택</string>
+    <string name="worldcup_play">월드컵실행</string>
+    <string name="worldcup_result">월드컵결과</string>
 
     <!-- Home Screen -->
     <string name="home_app_bar_title">개냥컵 로고</string>


### PR DESCRIPTION
## Job title
<!-- 어떤 작업을 했는지, 무엇을 위해서 했는지 간략하게 적어주세요! -->
<!-- 영어 혹은 한국어로 적어주세요! -->

## What did you do? or What Will you do?

- [x] 월드컵 실행 화면 개발
- [x] Rich Text 커스텀 - 텍스트 안 바뀌는 버그 수정
- [x] 라우팅 기능 수정
- [x] 홈화면에서 월드컵 화면으로 이동

## work result
<!-- 눈에 띄는 결과물이 있어서 첨부하고 싶으면 적어주세요! -->
<img src="https://github.com/DaeJol/catdogcup/assets/26290540/ec58fc90-26c7-4684-8b84-9f6918c22a40" width="300" height="650"/>


## code discussion / review request / concern
### 리팩터링할 것
1. 이미지 로딩이 너무 느리다. 월드컵 실행 이전에 미리 불러오던가 해야할 것 같다.
2. 월드컵 이미지 데이터 불러올 때 대기시간이 길어서 가만히 멈춘 것 같다. 로딩바를 넣던가 이미지 생성 중입니다 화면을 만들자.
